### PR TITLE
Revert "[ci] Run SPM and CocoaPod jobs with xcode 13"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,13 @@ workflows:
         jobs:
             - macos-job:
                 name: SPM
-                xcode: "13.0.0"
+                xcode: "12.0.0" # Required for using binary frameworks with SPM
                 spm: true
             - macos-job:
                 name: Carthage
                 carthage: true
             - macos-job:
                 name: CocoaPods
-                xcode: "13.0.0"
                 cocoapods: true
 
 jobs:


### PR DESCRIPTION
This reverts commit 728e0d200276d80ef21adb91d9174c7320fdaefa.

We revert this change because it caused unexpected binary compatibility
issues for customers.