### PR TITLE
[scripts] Do not error in license checker if license needs updating

### DIFF
--- a/scripts/release/check-license.sh
+++ b/scripts/release/check-license.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # This script fetches the LICENSE.md from the version specified in Package.swift
-# and returns 0 if it matches the LICENSE.md in this repository.
+# and outputs whether it matches the LICENSE.md in this repository. It modifies the
+# LICENSE.md file so a commit of the file will update the license.
 
 set -eo pipefail
 
@@ -23,10 +24,9 @@ NEW_LICENSE="${ROOT_DIR}/LICENSE.md"
 STATUS="$(cmp --silent $OLD_LICENSE $NEW_LICENSE; echo $?)"
 
 if [[ $STATUS -ne 0 ]]; then  # if status isn't equal to 0, then execute code
-    echo "LICENSE.md in the binary and inside this repository doesn't match."
-    exit 1
+    echo "The LICENSE.md in the binary and inside this repository doesn't match."
 else
     echo "The LICENSE.md in the binary and inside this repository matches."
-    rm -rf "${ROOT_DIR}/LICENSE.md.old"
-    exit 0
 fi
+rm -rf "${ROOT_DIR}/LICENSE.md.old"
+exit 0


### PR DESCRIPTION
This means our jobs don't fail when we use this script while creating a new PR from Common