### PR TITLE
create_new_release.yml should create releases for lts branches as well

### DIFF
--- a/.github/workflows/create_new_release.yml
+++ b/.github/workflows/create_new_release.yml
@@ -9,7 +9,8 @@ jobs:
       github.event.pull_request.merged &&
       (startsWith(github.head_ref, 'release-v') ||
       startsWith(github.head_ref, 'release/v')) &&
-      startsWith(github.base_ref, 'main')
+      (startsWith(github.base_ref, 'main') || 
+      startsWith(github.base_ref, 'lts/v'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Example of not released PR: https://github.com/mapbox/mapbox-common-ios/pull/237