### PR TITLE
Add CODEOWNERS, exclude paths we update automatically during the release process.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+* @mapbox/core-sdk
+Package.swift
+README.md
+Tests/Integration/Carthage/Cartfile
+Tests/Integration/CocoaPods/Podfile


### PR DESCRIPTION
Discussion here: https://mapbox.slack.com/archives/C0FPJKE5V/p1709564188926159