### PR TITLE
[package] Bump minimum iOS version from v10 to v12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let checksum = "9b0500ed7b44c38cf9daa86624359e842e628b753edd5d156455b32b7b962af3
 
 let package = Package(
     name: "MapboxCommon",
-    platforms: [.iOS(.v10), .macOS(.v10_15), .custom("visionos", versionString: "1.0")],
+    platforms: [.iOS(.v12), .macOS(.v10_15), .custom("visionos", versionString: "1.0")],
     products: [
         .library(
             name: "MapboxCommon",

--- a/scripts/release/Package.swift
+++ b/scripts/release/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Bumps minimum iOS version from v10 to v12 as v12 is now a requirement for App Store uploads.