### PR TITLE
[security] Fix vulnerability in GH action

### DIFF
--- a/.github/workflows/create_new_release.yml
+++ b/.github/workflows/create_new_release.yml
@@ -9,7 +9,7 @@ jobs:
       github.event.pull_request.merged &&
       (startsWith(github.head_ref, 'release-v') ||
       startsWith(github.head_ref, 'release/v')) &&
-      (startsWith(github.base_ref, 'main') || 
+      (startsWith(github.base_ref, 'main') ||
       startsWith(github.base_ref, 'lts/v'))
     runs-on: ubuntu-latest
     steps:
@@ -18,7 +18,8 @@ jobs:
           fetch-depth: 0
       - name: Create release
         run: |
-          VERSION=$(echo "${{github.head_ref}}" | sed -E "s/^release[\/-]//")
-          gh release create $VERSION --notes "Bump to $VERSION" --title "Release-$VERSION" --target "${{github.head_ref}}"
+          VERSION=$(echo "${GITHUB_REF}" | sed -E "s/^release[\/-]//")
+          gh release create $VERSION --notes "Bump to $VERSION" --title "Release-$VERSION" --target "${GITHUB_REF}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REF: ${{github.head_ref}}

--- a/.github/workflows/merge_release_pr.yml
+++ b/.github/workflows/merge_release_pr.yml
@@ -37,7 +37,10 @@ jobs:
             sleep 720
             curl --request POST \
             --url https://circleci.com/api/v2/project/github/mapbox/mapbox-common-ios/pipeline \
-            --header 'Circle-Token: ${{ secrets.CCI_TOKEN }}' \
+            --header 'Circle-Token: ${CIRCLECI_TOKEN}' \
             --header 'content-type: application/json' \
-            --data '{"branch":"${{ github.head_ref }}"}'
+            --data '{"branch":"${GITHUB_REF}"}'
           done
+        env:
+          GITHUB_REF: ${{ github.head_ref }}
+          CIRCLECI_TOKEN: ${{ secrets.CCI_TOKEN }}


### PR DESCRIPTION
Under some very specific circumstances, if a release PR was made to the repo with some special characters, it could allow someone to execute shell code on the GH action environment.

Not much of a big deal, because it would require that the shell command be part of the branch name, along with some extra markup to avoid clashing with the action code, but still, better to be safe than sorry.

CORESDK-2545