### PR TITLE
[ci] Fix release automation

### DIFF
--- a/.github/workflows/create_new_release.yml
+++ b/.github/workflows/create_new_release.yml
@@ -18,8 +18,7 @@ jobs:
           fetch-depth: 0
       - name: Create release
         run: |
-          VERSION=$(echo "${GITHUB_REF}" | sed -E "s/^release[\/-]//")
-          gh release create $VERSION --notes "Bump to $VERSION" --title "Release-$VERSION" --target "${GITHUB_REF}"
+          VERSION=$(echo "${GITHUB_HEAD_REF}" | sed -E "s/^release[\/-]//")
+          gh release create $VERSION --notes "Bump to $VERSION" --title "Release-$VERSION" --target "${GITHUB_HEAD_REF}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REF: ${{github.head_ref}}

--- a/.github/workflows/merge_release_pr.yml
+++ b/.github/workflows/merge_release_pr.yml
@@ -39,8 +39,7 @@ jobs:
             --url https://circleci.com/api/v2/project/github/mapbox/mapbox-common-ios/pipeline \
             --header 'Circle-Token: ${CIRCLECI_TOKEN}' \
             --header 'content-type: application/json' \
-            --data '{"branch":"${GITHUB_REF}"}'
+            --data '{"branch":"${GITHUB_HEAD_REF}"}'
           done
         env:
-          GITHUB_REF: ${{ github.head_ref }}
           CIRCLECI_TOKEN: ${{ secrets.CCI_TOKEN }}


### PR DESCRIPTION
Attempt to fix an automation making a release.
Release creation is broken since https://github.com/mapbox/mapbox-common-ios/pull/263

https://github.com/mapbox/mapbox-common-ios/actions/runs/9404274052/job/25902809232

```
Run VERSION=$(echo "${GITHUB_REF}" | sed -E "s/^release[\/-]//")
  VERSION=$(echo "${GITHUB_REF}" | sed -E "s/^release[\/-]//")
  gh release create $VERSION --notes "Bump to $VERSION" --title "Release-$VERSION" --target "${GITHUB_REF}"
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
    GITHUB_REF: release/v[2](https://github.com/mapbox/mapbox-common-ios/actions/runs/9404274052/job/25902809232#step:3:2)4.5.0-beta.3
```
```
HTTP 422: Validation Failed (https://api.github.com/repos/mapbox/mapbox-common-ios/releases)
pre_receive Sorry, branch or tag names starting with 'refs/' are not allowed.
Published releases must have a valid tag
Error: Process completed with exit code 1.
```

seems custom GITHUB_REF was shadowed by the default GITHUB_REF with other contents (starting with refs/).
There is another default variable that should contain what we need, let's use it and keep an eye on automation (it's problematic to test it outside of the release process but it's the last step that is easy to do manually if it fails).

The list of default environment variables is here:
https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
