### PR TITLE
Tagging @search-sdk-team for Common releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
                                 "type": "section",
                                 "text": {
                                     "type": "mrkdwn",
-                                    "text": "Common SDK <https://github.com/mapbox/mapbox-sdk-common/releases/tag/$CIRCLE_TAG | $CIRCLE_TAG> has been released. cc @gl-native-team @maps-android @maps-ios"
+                                    "text": "Common SDK <https://github.com/mapbox/mapbox-sdk-common/releases/tag/$CIRCLE_TAG | $CIRCLE_TAG> has been released. cc @gl-native-team @maps-android @maps-ios @search-sdk-team"
                                 }
                             }
                         ]


### PR DESCRIPTION
The Search SDK team would like to be tagged with new Common releases, in this message: https://mapbox.slack.com/archives/C01M5T7N8D9/p1718359273557059

So that we can be up to date with our releases for other teams.