### PR TITLE
[ci] Add a check to make sure we will not release v24.0 - v24.5 with wrong Turf dependency.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ workflows:
             - macos-job:
                 name: CocoaPods
                 cocoapods: true
+            - verify_branch:
+                name: Verify branch
     notify_release:
         jobs:
         - notify_release:
@@ -168,3 +170,24 @@ jobs:
                             }
                         ]
                     }
+    verify_branch:
+        docker:
+            - image: cimg/base:stable
+        resource_class: small
+        steps:
+            - run:
+                name: Verify version
+                command: |
+                    echo "We check branch here instead of running job with filter because we need to run it on every PR to make job mandatory in GH."
+                    if [[ ${CIRCLE_BRANCH} == release* ]]; then
+                        VERSION=$(echo "${CIRCLE_BRANCH}" | sed -E "s/^release[\/-]v//")
+                        MAJOR=$(echo "${VERSION}" | cut -d. -f1)
+                        MINOR=$(echo "${VERSION}" | cut -d. -f2)
+                        echo "Version: ${VERSION} MAJOR: ${MAJOR} MINOR: ${MINOR}"
+                        if [[ "${MAJOR}" -eq 24 ]]; then
+                            if [[ "${MINOR}" -lt 6 ]]; then
+                                echo "Version ${VERSION} is not allowed to be released from the main branch because of incorrect dependencies in SPM. Please use lts branch (see lts/v24.5 for example)."
+                                exit 1
+                            fi
+                        fi
+                    fi


### PR DESCRIPTION
Now if we make PR from the old v24 branch to main we may release mapbox-common ios with wrong Turf dependency

The problem has been fixed since v24.6: https://github.com/mapbox/mapbox-sdk-common/pull/4664
patches prior to v24.6.x should be released from the dedicated branches (see 24.5.1 for reference: https://github.com/mapbox/mapbox-common-ios/pull/455)

But to prevent incorrect releases I'm adding a jom and going to make in mandatory.
I tested it with PRs from branches with name release/v24.0.-test, release/v24.6.-test, worked fine:

fails for v24.0
https://app.circleci.com/pipelines/github/mapbox/mapbox-common-ios/1646/workflows/5a0d75de-a2dc-4851-8b0f-c103d9764fc6/jobs/4155

success for v24.6:
https://app.circleci.com/pipelines/github/mapbox/mapbox-common-ios/1645/workflows/61f463f9-b3ee-41ee-b9b7-688417e2ed0c/jobs/4152

success for the branch not starting with release (this one).
